### PR TITLE
Improve full screen mode on Safari

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1113,7 +1113,7 @@ var Module = null;
    };
 
    EmscriptenRunner.prototype.requestFullScreen = function () {
-     this._canvas.requestFullscreen();
+     getfullscreenenabler().call(this._canvas);
    };
 
    /*
@@ -1972,7 +1972,7 @@ var Module = null;
        var self = this;
        var fullScreenChangeHandler = function() {
                                        if (!(document.mozFullScreenElement || document.fullScreenElement)) {
-                                         resizeCanvas(canvas, scale, css_resolution, aspectRatio);
+                                         resizeCanvas(self.canvas, self.scale, self.css_resolution, self.aspectRatio);
                                        }
                                      };
        if ('onfullscreenchange' in document) {


### PR DESCRIPTION
This patch was written from an archive.org perspective and fixes two problems in `loader.js`:

### Calling requestFullscreen

When running Safari, when you hit the _Full Screen View_ button on an active emulator, the following error happens:

> `TypeError: this._canvas.requestFullscreen is not a function. (In 'this._canvas.requestFullscreen()', 'this._canvas.requestFullscreen' is undefined)`

This is because `EmscriptenRunner.requestFullScreen` calls `requestFullscreen` on the `Canvas` instead of going through `getfullscreenenabler()`, which will pick the proper (prefixed) version of `requestFullscreen`.

### Adjusting the canvas scale

With the first part in place, things work (at least in vMac) but are not scaled properly. This is hard to see on a 4:3 screen but it becomes very obvious on different screen sizes.

The problem is the following, which happens after the canvas is made full screen:

> `ReferenceError: Can't find variable: scale`

This is because the `fullScreenChangeHandler` can't reference the variables it needs because they are under `this`, which gets lost in this handler.
